### PR TITLE
修复因换行符导致docker build在windows平台下无法运行

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,8 @@ ADD . .
 
 RUN pip --no-cache-dir install --upgrade pip && pip --no-cache-dir install .[api,cloud]
 
+RUN sed -i 's/\r$//' /opt/app/bin/startup.sh
+
+RUN chmod +x /opt/app/bin/startup.sh
+
 ENTRYPOINT ["bin/startup.sh"]


### PR DESCRIPTION
修复因换行符导致docker build在windows平台下无法运行，问题报错：exec bin/startup.sh: no such file or directory